### PR TITLE
Today in Bitcoin/LN history snippet on homepage

### DIFF
--- a/generate_homepage_xml.py
+++ b/generate_homepage_xml.py
@@ -554,6 +554,9 @@ if __name__ == "__main__":
     logger.info(f"start_date: {start_date_str}")
     logger.info(f"current_date_str: {current_date_str}")
 
+    month_name = gen.month_dict[int(current_date.month)]
+    str_month_year = f"{month_name}_{int(current_date.year)}"
+
     recent_data_list = []
     active_data_list = []
     random_flashback_data_list = []  # Randomly look back X years, summarize and surface a combined summary discussion with 5+ replies
@@ -710,7 +713,9 @@ if __name__ == "__main__":
 
         logger.info(f"No. of 'Today in history' posts collected: {len(today_in_history_data_list)}")
 
-    json_file_path = r"static/homepage.json"
+    json_file_path = fr"static/homepage/{str_month_year}/{current_date_str}-homepage.json"
+    dirname = os.path.dirname(json_file_path)
+    os.makedirs(dirname, exist_ok=True)
 
     xml_ids = gen.get_existing_json_ids(file_path=json_file_path)
     recent_post_ids = [gen.get_id(data['_source']['title']) for data in recent_data_list]

--- a/static/homepage.json
+++ b/static/homepage.json
@@ -1,5 +1,5 @@
 {
-    "header_summary": "Recent debates within the Bitcoin development community have focused on advancing Layer 2 solutions, notably improvements to the Lightning Network, to enhance security and efficiency. A primary goal is to design a consensus-change resolution that safeguards low-value lightning payments and optimizes multi-party off-chain constructions without unfairly benefiting miners with smaller hash rates. Proposed strategies include non-interactive processes to minimize reserves for fee-bumping and locked UTXOs, while averting adversarial tactics like pinning or replacement cycling.\n\nSecurity measures against the exploitation of outdated off-chain states are also under scrutiny, with the introduction of short-lived proofs and sequential time windows to validate off-chain states. To address the unpredictable transaction fee landscape, a median-time-past mechanism could refine the handling of HTLCs and fee estimation. Concurrently, proposals to refine the lightning address protocol aim to bolster user experience, privacy, and security by allowing anonymous acquisition of `node_id` and payment details through DNS records and onion messages.\n\nThere is a consensus on the importance of practical testing for these initiatives, particularly to validate their performance on the Lightning Network. The research community is invited to examine issues such as pinning, replacement cycling, and miner incentives to ensure a robust fee market and a decentralized mining structure, especially relevant as mining subsidies diminish. Advocates suggest that ethical mainnet trials could yield valuable insights. For a more in-depth analysis, interested parties can refer to the discussions archived on the [Bitcoin Development Mailing List Archive](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-June/018011.html) and the [Lightning-dev mailing list](https://lists.linuxfoundation.org/pipermail/lightning-dev/2019-July/002064.html).",
+    "header_summary": "The Bitcoin community is actively addressing technical challenges in enhancing Layer 2 solutions, notably the Lightning Network, with a focus on non-interactive processes, UTXO reduction, and fee-bumping reserves. Solutions must prevent manipulative tactics such as pinning or replacement cycling, ensure security for low-value payments, and optimize for off-chain multi-party constructions without giving miners unfair advantage. Advanced cryptographic solutions, like those in Peter Todd's op_expire proposal, are under consideration, and thorough testing and community input are sought to validate these solutions and maintain a healthy fee market and mining ecosystem.\n\nIn addition to core improvements, discussions aim to refine the lightning address protocol to bolster user experience, security, and privacy. Current vulnerabilities like IP address exposure and invoice swapping are being addressed with proposals for private node ID retrieval and secure payment detail acquisition, possibly via DNS TXT records and onion messaging. Community feedback is sought before drafting these proposals into a bLIP, with an emphasis on simplicity and the best fit for domain owners, acknowledging Rusty Russell and Matt Corallo for their contributions.",
     "recent_posts": [
         {
             "id": "022174",
@@ -9,12 +9,12 @@
                 "Antoine Riard"
             ],
             "published_at": "2023-11-15T18:14:28+00:00",
-            "summary": "- Solutions must be non-interactive, minimize reserves and UTXOs, and prevent malicious activities.\n- Must ensure low-value payment security, optimize script efficiency, and avoid miner manipulation.\n- Compatibility with current approaches and further research by the community are imperative.",
+            "summary": "- Solutions for Bitcoin Layer 2 issues must be non-interactive and prevent malicious attacks.\n- They should ensure Lightning payment security and efficiency in multi-party off-chain constructions.\n- The aim is to validate solutions with end-to-end implementation and encourage further research.",
             "n_threads": 3,
             "dev_name": "bitcoin-dev",
             "contributors": [],
             "file_path": "static/bitcoin-dev/Nov_2023/022174_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml",
-            "combined_summ_file_path": ""
+            "combined_summ_file_path": "static/bitcoin-dev/Nov_2023/combined_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml"
         },
         {
             "id": "022173",
@@ -24,7 +24,7 @@
                 "Antoine Riard"
             ],
             "published_at": "2023-11-15T17:53:57+00:00",
-            "summary": "- Security in Lightning Network is challenged by expired off-chain outputs and revoked states.\n- Op_expire operation aids in managing block space demand and fee rate asymmetries.\n- LN-symmetry and risks of miner counterparties highlight complexity in maintaining penalties.",
+            "summary": "- Expired off-chain outputs and revoked state use threaten Lightning Network security and efficiency.\n- Op_expire aids in Discreet Log Contracts and helps nodes estimate fees for secure transactions.\n- LN-symmetry and miner counterparties introduce risks to maintaining penalty abilities in Lightning Network.",
             "n_threads": 1,
             "dev_name": "bitcoin-dev",
             "contributors": [],
@@ -39,7 +39,7 @@
                 "Bastien TEINTURIER"
             ],
             "published_at": "2023-11-16T13:51:26+00:00",
-            "summary": "- The lightning address protocol improvements focus on privacy and security enhancements.\n- DNS `TXT` records may link domains to nodes, preserving sender privacy.\n- The author plans a bLIP post-community feedback, with simplified implementation of selected options.",
+            "summary": "- The lightning address protocol aims to enhance UX while addressing privacy and security issues.\n- Proposed design links domains to nodes via DNS `TXT` records for private identification.\n- The author's focus is refining proposals into a bLIP after community feedback and reviews.",
             "n_threads": 1,
             "dev_name": "lightning-dev",
             "contributors": [],
@@ -54,12 +54,12 @@
                 "Antoine Riard"
             ],
             "published_at": "2023-11-15T18:14:28+00:00",
-            "summary": "- Key Layer 2 solutions must address security, scalability, and minimize locked UTXOs.\n- Solutions should maintain competitiveness and prevent miner fee manipulation.\n- Further research is necessary to assess solutions' effectiveness on the Lightning Network.",
+            "summary": "- Critical consensus-change solutions must secure low-value payments without local mempool reliance.\n- The ideal approach reduces witness size and guards against miner fee manipulation.\n- Further research and testing are vital for sustainable Bitcoin Layer 2 fee markets.",
             "n_threads": 3,
             "dev_name": "lightning-dev",
             "contributors": [],
             "file_path": "static/lightning-dev/Nov_2023/004202_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml",
-            "combined_summ_file_path": ""
+            "combined_summ_file_path": "static/lightning-dev/Nov_2023/combined_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml"
         }
     ],
     "active_posts": [
@@ -71,7 +71,7 @@
                 "Peter Todd"
             ],
             "published_at": "2023-10-21T00:09:16+00:00",
-            "summary": "- The email addresses a flaw where HTLC-preimage paths don't expire, impacting urgency.\n- OP_Expire is suggested as a solution, with mechanisms like the Coinbase Bit for soft forking.\n- An alternative proposal uses nLockTime for expiration, similar to OP_CheckLockTimeVerify.",
+            "summary": "- HTLC-preimage path remains active after HTLC-timeout path becomes spendable, creating urgency issues.\n- Sender proposes OP_Expire and a soft-fork upgrade to align with Bitcoin's coinbase maturity concept.\n- OP_Expire would prevent HTLC preimage spending post-expiration, reverting control to the other party.",
             "n_threads": 25,
             "dev_name": "bitcoin-dev",
             "contributors": [
@@ -92,7 +92,7 @@
                 "Bryan Bishop"
             ],
             "published_at": "2023-11-07T15:37:22+00:00",
-            "summary": "- The Bitcoin-dev mailing list must move since the Linux Foundation is ending its hosting.\n- Moderators suggest decentralized archiving and improved tools for content moderation.\n- Community feedback is sought on alternatives like Google Groups for future hosting.",
+            "summary": "- The Bitcoin-dev mailing list is transitioning hosts due to the Linux Foundation's decision.\n- Moderators suggest decentralized archiving and blockchain timestamps to preserve content.\n- The community is considering various hosting options and seeking feedback on the migration.",
             "n_threads": 25,
             "dev_name": "bitcoin-dev",
             "contributors": [
@@ -127,7 +127,7 @@
                 "jlspc"
             ],
             "published_at": "2023-09-08T18:54:46+00:00",
-            "summary": "- Simple covenants could enable mass creation of Lightning channels without user signatures.\n- Timeout-trees avoid constant user action for rolling over off-chain bitcoin.\n- Incorporating CTV or APO into consensus rules could significantly scale the Lightning Network.",
+            "summary": "- Simple covenants could enable UTXO to create multiple Lightning channels without signatures.\n- Timeout-trees with rollover capability can scale Lightning, allowing off-chain fund access.\n- The proposal suggests updating Bitcoin consensus rules with CTV or APO to enhance scalability.",
             "n_threads": 15,
             "dev_name": "bitcoin-dev",
             "contributors": [
@@ -148,7 +148,7 @@
                 "Peter Todd"
             ],
             "published_at": "2023-10-21T00:09:16+00:00",
-            "summary": "- The sender proposes using OP_Expire and Coinbase Bit soft-fork to enforce HTLC urgency.\n- They suggest redefining the nVersion field for coinbase-like txout handling post-100 blocks.\n- HTLC protocols could utilize OP_Expire, giving receivers a deadline to act before losing control.",
+            "summary": "- The sender recommends using OP_Expire and Coinbase Bit to ensure HTLC urgency.\n- Transactions can be made to expire like coinbase transactions, enhancing security.\n- OP_Expire prevents spending unless certain conditions, including block height, are met.",
             "n_threads": 27,
             "dev_name": "lightning-dev",
             "contributors": [
@@ -170,7 +170,7 @@
                 "jlspc"
             ],
             "published_at": "2023-09-08T18:54:46+00:00",
-            "summary": "- Implementing simple covenants improves the Lightning Network's scalability for casual users.\n- Timeout-trees enable channels to operate off-chain with periodic on-chain balance updates.\n- The email advocates for Bitcoin consensus changes to facilitate widespread Lightning adoption.",
+            "summary": "- Creating channels for numerous casual users under the current Bitcoin rules is challenging.\n- Implementing covenants and timeout-trees can vastly improve Lightning's scalability.\n- The email suggests adding CTV or APO to Bitcoin's rules could make Lightning widely used.",
             "n_threads": 17,
             "dev_name": "lightning-dev",
             "contributors": [
@@ -192,7 +192,7 @@
                 "Thomas Voegtlin"
             ],
             "published_at": "2023-06-13T08:10:29+00:00",
-            "summary": "- ThomasV suggests adding bundled payments to BOLT-11 for non-custodial services' prepayments.\n- The proposal includes waiting for all HTLCs before fulfilling prepayments and handling main payments.\n- Implementation would aid non-custodial services like ACINQ and alleviate regulatory and attack risks.",
+            "summary": "- ThomasV proposes extending BOLT-11 for bundled prepayments to prevent service attacks.\n- Bundled invoice payments would secure non-custodian exchanges against fee-denial exploits.\n- The change aims to equalize service providers while maintaining non-custodian operations under MICA.",
             "n_threads": 14,
             "dev_name": "lightning-dev",
             "contributors": [
@@ -206,5 +206,50 @@
             "file_path": "static/lightning-dev/June_2023/003977_Proposal-Bundled-payments.xml",
             "combined_summ_file_path": "static/lightning-dev/June_2023/combined_Proposal-Bundled-payments.xml"
         }
-    ]
+    ],
+    "random_flashback_posts": [
+        {
+            "id": "010209",
+            "title": "Adjusted difficulty depending on relative blocksize",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2015-August/010209.html",
+            "authors": [
+                "Jakob R\u00f6nnb\u00e4ck"
+            ],
+            "published_at": "2015-08-14T09:59:32+00:00",
+            "summary": "- Jakob R\u00f6nnb\u00e4ck proposes difficulty adjustment based on block size relative to the average.\n- Difficulty changes occur by multiplying with the size difference from the average block.\n- The idea encourages 1MB blocks for now, aiming to maximize fees in the future.",
+            "n_threads": 12,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Adam Back",
+                "Angel Leon",
+                "Anthony Towns",
+                "Tom Harding",
+                "Warren Togami Jr."
+            ],
+            "file_path": "static/bitcoin-dev/Aug_2015/010209_Adjusted-difficulty-depending-on-relative-blocksize.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Aug_2015/combined_Adjusted-difficulty-depending-on-relative-blocksize.xml"
+        },
+        {
+            "id": "002826",
+            "title": "Hold fees: 402 Payment Required for Lightning itself",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2020-October/002826.html",
+            "authors": [
+                "Joost Jager"
+            ],
+            "published_at": "2020-10-12T11:03:49+00:00",
+            "summary": "- Lightning network concerns include spam and channel disruption; mitigation limits honest users.\n- Proposed hold fee system charges for forwarded HTLCs based on lock time and value.\n- Asymmetric hold fees prevent jamming and encourage selective route construction.",
+            "n_threads": 29,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Antoine Riard",
+                "Bastien TEINTURIER",
+                "Christian Decker",
+                "Rusty Russell",
+                "ZmnSCPxj"
+            ],
+            "file_path": "static/lightning-dev/Oct_2020/002826_Hold-fees-402-Payment-Required-for-Lightning-itself.xml",
+            "combined_summ_file_path": "static/lightning-dev/Oct_2020/combined_Hold-fees-402-Payment-Required-for-Lightning-itself.xml"
+        }
+    ],
+    "today_in_history_posts": []
 }

--- a/static/homepage/Nov_2023/2023-11-20-homepage.json
+++ b/static/homepage/Nov_2023/2023-11-20-homepage.json
@@ -1,0 +1,289 @@
+{
+    "header_summary": "John's analysis delves into optimizing blockchain technology's trade-off between trust/safety and capital efficiency by proposing a payment channel system with pre-paid cost-of-capital fees for a potential 2.1-year active duration. He suggests a manageable timeout-tree system within blockchain capacity, advocating for a minimum leaf value of 21,000 satoshis to promote honest behavior and estimating significant block space usage for processing these leaves. His findings, based on a Python program, predict a 1.55-year inactive lifetime for channels and an expected cost of 2.5% of user funds, though specific resource links are omitted.\n\nAntoine Riard adds to the dialogue by proposing a consensus-change based solution for Bitcoin's Layer 2, aimed at minimizing reserves for fee-bumping and unspent transaction outputs while ensuring strong protection against attacks and compatibility with time-sensitive off-chain states. Riard's approach emphasizes security without relying on probabilistic past data, suggests using advanced cryptographic methods, and calls for comprehensive testing, particularly on the Lightning Network, to maintain a reliable fee market and decentralized mining post-mining subsidies.\n\nFor those interested in a more detailed discussion of these blockchain and Bitcoin Layer 2 considerations, the complete conversations and additional insights can be found on the Bitcoin development mailing list archive at [Bitcoin-dev Mailing List](https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2020-June/018011.html).",
+    "recent_posts": [
+        {
+            "id": "022176",
+            "title": "Purely off-chain coin colouring",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022176.html",
+            "authors": [
+                "Anthony Towns"
+            ],
+            "published_at": "2023-11-17T07:58:34+00:00",
+            "summary": "Apologies, but it seems the context intended for summarization has not been provided. Could you please supply the content of the email you're referencing? I'll then be able to help summarize it for you.",
+            "n_threads": 12,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Aymeric Vitte",
+                "Casey Rodarmor",
+                "Peter Todd",
+                "Rijndael",
+                "alicexbt"
+            ],
+            "file_path": "static/bitcoin-dev/Nov_2023/022176_Purely-off-chain-coin-colouring.xml",
+            "combined_summ_file_path": ""
+        },
+        {
+            "id": "022175",
+            "title": "Scaling Lightning With Simple Covenants",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022175.html",
+            "authors": [
+                "jlspc"
+            ],
+            "published_at": "2023-11-15T19:59:37+00:00",
+            "summary": "- John examines pre-paid fees in blockchain payment channels to balance trust and efficiency.\n- He outlines leaf processing limits and minimum value for user honesty within blockchain capacity.\n- A Python script analyzes system scalability; results indicate significant block space use and cost.",
+            "n_threads": 15,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Anthony Towns",
+                "Antoine Riard",
+                "Erik Aronesty",
+                "Rusty Russell",
+                "ZmnSCPxj"
+            ],
+            "file_path": "static/bitcoin-dev/Nov_2023/022175_Scaling-Lightning-With-Simple-Covenants.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Nov_2023/combined_Scaling-Lightning-With-Simple-Covenants.xml"
+        },
+        {
+            "id": "022174",
+            "title": "On solving pinning, replacement cycling and mempool issues for bitcoin second-layers",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022174.html",
+            "authors": [
+                "Antoine Riard"
+            ],
+            "published_at": "2023-11-15T18:14:28+00:00",
+            "summary": "- The solution must be non-interactive, minimize reserves and UTXOs, and avert malicious activity.\n- It should ensure security for low-value payments and be efficient through optimized scripting.\n- Community is urged to test solutions, aiming for a sustainable fee market and decentralized mining.",
+            "n_threads": 3,
+            "dev_name": "bitcoin-dev",
+            "contributors": [],
+            "file_path": "static/bitcoin-dev/Nov_2023/022174_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Nov_2023/combined_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml"
+        },
+        {
+            "id": "004209",
+            "title": "Lightning Address in a Bolt 12 world",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-November/004209.html",
+            "authors": [
+                "Andy Schroder"
+            ],
+            "published_at": "2023-11-17T18:07:15+00:00",
+            "summary": "It seems like the context you mentioned for summarizing is not included in your message. Could you please provide the text you want me to summarize?",
+            "n_threads": 6,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Bastien TEINTURIER",
+                "Tony Giorgio"
+            ],
+            "file_path": "static/lightning-dev/Nov_2023/004209_Lightning-Address-in-a-Bolt-12-world.xml",
+            "combined_summ_file_path": ""
+        },
+        {
+            "id": "004202",
+            "title": "On solving pinning, replacement cycling and mempool issues for bitcoin second-layers",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-November/004202.html",
+            "authors": [
+                "Antoine Riard"
+            ],
+            "published_at": "2023-11-15T18:14:28+00:00",
+            "summary": "- Solutions must balance security, fees, and script efficiency for Bitcoin Layer 2.\n- Further exploration of alternative proposals and cryptographic methods is needed.\n- Ongoing research into miner incentives and fee markets is crucial for sustainability.",
+            "n_threads": 3,
+            "dev_name": "lightning-dev",
+            "contributors": [],
+            "file_path": "static/lightning-dev/Nov_2023/004202_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml",
+            "combined_summ_file_path": "static/lightning-dev/Nov_2023/combined_On-solving-pinning-replacement-cycling-and-mempool-issues-for-bitcoin-second-layers.xml"
+        }
+    ],
+    "active_posts": [
+        {
+            "id": "004122",
+            "title": "Full Disclosure: CVE-2023-40231 / CVE-2023-40232 / CVE-2023-40233 / CVE-2023-40234 \"All your mempool are belong to us\"",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-October/004122.html",
+            "authors": [
+                "Antoine Riard"
+            ],
+            "published_at": "2023-10-16T16:57:36+00:00",
+            "summary": "- A new transaction-relay jamming attack, replacement cycling, was discovered in December 2022.\n- Mitigation strategies include rebroadcasting, preimage monitoring, and CLTV delta adjustments.\n- Full disclosure of the attack and associated CVEs was made on October 16, 2023.",
+            "n_threads": 65,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Bastien TEINTURIER",
+                "David A. Harding",
+                "Jochen Hoenicke",
+                "Matt Corallo",
+                "Matt Morehouse",
+                "Nadav Ivgi",
+                "Nagaev Boris",
+                "Olaoluwa Osuntokun",
+                "Peter Todd"
+            ],
+            "file_path": "static/bitcoin-dev/Oct_2023/004122_Full-Disclosure-CVE-2023-40231-CVE-2023-40232-CVE-2023-40233-CVE-2023-40234-All-your-mempool-are-belong-to-us-.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Oct_2023/combined_Full-Disclosure-CVE-2023-40231-CVE-2023-40232-CVE-2023-40233-CVE-2023-40234-All-your-mempool-are-belong-to-us-.xml"
+        },
+        {
+            "id": "022134",
+            "title": "Future of the bitcoin-dev mailing list",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-November/022134.html",
+            "authors": [
+                "Bryan Bishop"
+            ],
+            "published_at": "2023-11-07T15:37:22+00:00",
+            "summary": "- The Linux Foundation's halt in hosting mailing lists prompts transition for Bitcoin developers.\n- New host options include web forums and integrated services like Google Groups or groups.io.\n- Community feedback is sought on migration pathways affecting Bitcoin development's future.",
+            "n_threads": 25,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Ademan",
+                "Ali Sherief",
+                "Andreas Schildbach",
+                "Andrew Chow",
+                "Anthony Towns",
+                "Antoine Riard",
+                "Christopher Allen",
+                "David A. Harding",
+                "Emil Pfeffer",
+                "Keagan McClelland",
+                "Overthefalls",
+                "Peter Todd",
+                "Ryan Breen",
+                "Tao Effect",
+                "William Casarin",
+                "alicexbt",
+                "email at yancy.lol",
+                "ponymontana",
+                "vjudeu at gazeta.pl"
+            ],
+            "file_path": "static/bitcoin-dev/Nov_2023/022134_Future-of-the-bitcoin-dev-mailing-list.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Nov_2023/combined_Future-of-the-bitcoin-dev-mailing-list.xml"
+        },
+        {
+            "id": "004163",
+            "title": "OP_Expire and Coinbase-Like Behavior: Making HTLCs Safer by Letting Transactions Expire Safely",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2023-October/004163.html",
+            "authors": [
+                "Peter Todd"
+            ],
+            "published_at": "2023-10-21T00:09:16+00:00",
+            "summary": "- OP_Expire terminates script evaluations if conditions such as unset Coinbase Bit arise.\n- The opcode creates a deadline in HTLC scripts, ensuring timely preimage spend before expiry.\n- Encoding expiration height as a delta is suggested, akin to OP_CheckLockTimeVerify's function.",
+            "n_threads": 25,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Antoine Riard",
+                "David A. Harding",
+                "Matt Morehouse",
+                "ZmnSCPxj",
+                "vjudeu at gazeta.pl"
+            ],
+            "file_path": "static/bitcoin-dev/Oct_2023/004163_OP-Expire-and-Coinbase-Like-Behavior-Making-HTLCs-Safer-by-Letting-Transactions-Expire-Safely.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/Oct_2023/combined_OP-Expire-and-Coinbase-Like-Behavior-Making-HTLCs-Safer-by-Letting-Transactions-Expire-Safely.xml"
+        },
+        {
+            "id": "004122",
+            "title": "Full Disclosure: CVE-2023-40231 / CVE-2023-40232 / CVE-2023-40233 / CVE-2023-40234 \"All your mempool are belong to us\"",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004122.html",
+            "authors": [
+                "Antoine Riard"
+            ],
+            "published_at": "2023-10-16T16:57:36+00:00",
+            "summary": "- A new attack threatens lightning channels by using replacement cycling.\n- Developers are urged to examine the impact on bitcoin applications with time-sensitive transactions.\n- Additional research is required to address package malleability pinning attacks.",
+            "n_threads": 65,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Bastien TEINTURIER",
+                "David A. Harding",
+                "Jochen Hoenicke",
+                "Matt Corallo",
+                "Matt Morehouse",
+                "Nadav Ivgi",
+                "Nagaev Boris",
+                "Olaoluwa Osuntokun",
+                "Peter Todd"
+            ],
+            "file_path": "static/lightning-dev/Oct_2023/004122_Full-Disclosure-CVE-2023-40231-CVE-2023-40232-CVE-2023-40233-CVE-2023-40234-All-your-mempool-are-belong-to-us-.xml",
+            "combined_summ_file_path": "static/lightning-dev/Oct_2023/combined_Full-Disclosure-CVE-2023-40231-CVE-2023-40232-CVE-2023-40233-CVE-2023-40234-All-your-mempool-are-belong-to-us-.xml"
+        },
+        {
+            "id": "004163",
+            "title": "OP_Expire and Coinbase-Like Behavior: Making HTLCs Safer by Letting Transactions Expire Safely",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-October/004163.html",
+            "authors": [
+                "Peter Todd"
+            ],
+            "published_at": "2023-10-21T00:09:16+00:00",
+            "summary": "- The sender proposes OP_Expire and Coinbase Bit fork for HTLC issues, restricting spendability.\n- Transactions would mimic coinbase txout handling, being spendable only after 100 additional blocks.\n- HTLC preimage branches would use OP_Expire, giving recipients a clear deadline to act.",
+            "n_threads": 27,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Antoine Riard",
+                "David A. Harding",
+                "Jorge Tim\u00f3n",
+                "Matt Morehouse",
+                "ZmnSCPxj",
+                "vjudeu at gazeta.pl"
+            ],
+            "file_path": "static/lightning-dev/Oct_2023/004163_OP-Expire-and-Coinbase-Like-Behavior-Making-HTLCs-Safer-by-Letting-Transactions-Expire-Safely.xml",
+            "combined_summ_file_path": "static/lightning-dev/Oct_2023/combined_OP-Expire-and-Coinbase-Like-Behavior-Making-HTLCs-Safer-by-Letting-Transactions-Expire-Safely.xml"
+        },
+        {
+            "id": "004092",
+            "title": "Scaling Lightning With Simple Covenants",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2023-September/004092.html",
+            "authors": [
+                "jlspc"
+            ],
+            "published_at": "2023-09-08T18:54:46+00:00",
+            "summary": "- Simple covenants and timeout-trees could greatly enhance Lightning Network scalability.\n- These innovations permit millions of casual users to use Lightning channels without complex processes.\n- Incorporating CTV or APO into Bitcoin's rules could make Lightning a common payment method.",
+            "n_threads": 17,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Anthony Towns",
+                "Antoine Riard",
+                "David A. Harding",
+                "Erik Aronesty",
+                "Rusty Russell",
+                "ZmnSCPxj"
+            ],
+            "file_path": "static/lightning-dev/Sept_2023/004092_Scaling-Lightning-With-Simple-Covenants.xml",
+            "combined_summ_file_path": "static/lightning-dev/Sept_2023/combined_Scaling-Lightning-With-Simple-Covenants.xml"
+        }
+    ],
+    "random_flashback_posts": [
+        {
+            "id": "014802",
+            "title": "Updating the Scaling Roadmap [Update]",
+            "link": "https://lists.linuxfoundation.org/pipermail/bitcoin-dev/2017-July/014802.html",
+            "authors": [
+                "Paul Sztorc"
+            ],
+            "published_at": "2017-07-17T17:13:30+00:00",
+            "summary": "- Paul Sztorc proposed an updated Core Scalability Roadmap, with a draft on GitHub.\n- Gregory Maxwell opposed the update and Tom Zander disagreed with its \"Bitcoin\" labeling.\n- The roadmap includes new technologies and suggests a potential block size increase via hard fork.",
+            "n_threads": 5,
+            "dev_name": "bitcoin-dev",
+            "contributors": [
+                "Alex Morcos",
+                "Peter Todd"
+            ],
+            "file_path": "static/bitcoin-dev/July_2017/014802_Updating-the-Scaling-Roadmap-Update-.xml",
+            "combined_summ_file_path": "static/bitcoin-dev/July_2017/combined_Updating-the-Scaling-Roadmap-Update-.xml"
+        },
+        {
+            "id": "001697",
+            "title": "CPFP Carve-Out for Fee-Prediction Issues in Contracting Applications (eg Lightning)",
+            "link": "https://lists.linuxfoundation.org/pipermail/lightning-dev/2018-November/001697.html",
+            "authors": [
+                "Matt Corallo"
+            ],
+            "published_at": "2018-11-29T19:37:54+00:00",
+            "summary": "- Lightning transactions involve pre-signed future transactions, but complexity causes channel issues.\n- Counterparties can disrupt or increase costs of Lightning transactions via feerate manipulation.\n- Tweaking Lightning transactions or marking them for RBF could improve security and relay issues.",
+            "n_threads": 16,
+            "dev_name": "lightning-dev",
+            "contributors": [
+                "Bob McElrath",
+                "David A. Harding",
+                "Jeremy",
+                "Johan Tor\u00e5s Halseth",
+                "Rusty Russell"
+            ],
+            "file_path": "static/lightning-dev/Nov_2018/001697_CPFP-Carve-Out-for-Fee-Prediction-Issues-in-Contracting-Applications-eg-Lightning-.xml",
+            "combined_summ_file_path": "static/lightning-dev/Nov_2018/combined_CPFP-Carve-Out-for-Fee-Prediction-Issues-in-Contracting-Applications-eg-Lightning-.xml"
+        }
+    ],
+    "today_in_history_posts": []
+}


### PR DESCRIPTION
There two fields are as follows:

#### “random_flashback_posts”:
- selected random doc from the dataframe of all docs using df.sample(n=1)
- check if this selected entire thread has more than 5 replies
- if yes, add it to the list else randomly select another thread, max docs to collect = 2

#### “today_in_history_posts”:
- get today’s date and month
- fetch all the docs that have been published on this date-month
- check if it is an original post. if yes, add it to the list
- basically this will get only the original posts that were created on this date and not the replies.