### PR TITLE
feat: Add threaded XML generation with nested conversation structure

### DIFF
--- a/.github/workflows/xmls_gen_cron_job.yml
+++ b/.github/workflows/xmls_gen_cron_job.yml
@@ -49,6 +49,6 @@ jobs:
         if git diff --staged --quiet; then
           echo "No changes to commit"
         else
-          git commit -m "Updated newly generated xml files"
+          git commit -m "Updated newly generated XML files with threading structure"
           git push
         fi

--- a/src/xml_utils.py
+++ b/src/xml_utils.py
@@ -82,8 +82,49 @@ class XMLReader:
         published = root.findall(".//atom:entry/atom:published", namespaces)[0].text
         # published = add_utc_if_not_present(published)
         indexed_at = ((datetime.now(timezone.utc)).replace(microsecond=0)).isoformat()
+        # Handle both old format (flat authors) and new format (threaded structure)
         authors = root.findall('atom:author/atom:name', namespaces)
-        author_list = [author.text for author in authors]
+        author_list = []
+        
+        if authors:
+            # Old format: flat author list
+            author_list = [author.text for author in authors]
+            logger.info(f"📄 XML READER: Found {len(author_list)} authors in flat format")
+        else:
+            # New format: check for threaded structure
+            thread_elem = root.find('atom:thread', namespaces)
+            if thread_elem is not None:
+                # Extract authors from threaded structure
+                messages = thread_elem.findall('.//message')
+                author_list = []
+                
+                def extract_authors_from_messages(parent_elem, depth=0):
+                    for message in parent_elem.findall('./message'):
+                        author_elem = message.find('author')
+                        if author_elem is not None and author_elem.text:
+                            # Format with threading info for display
+                            reply_to = message.get('reply_to', '')
+                            timestamp_elem = message.find('timestamp')
+                            timestamp = timestamp_elem.text if timestamp_elem is not None else ''
+                            
+                            if depth > 0 and reply_to:
+                                indent = "  " * depth
+                                author_display = f"{indent}↳ {author_elem.text} {timestamp} (replying to {reply_to})"
+                            else:
+                                author_display = f"{author_elem.text} {timestamp}"
+                            
+                            author_list.append(author_display)
+                        
+                        # Recursively process replies
+                        replies_elem = message.find('replies')
+                        if replies_elem is not None:
+                            extract_authors_from_messages(replies_elem, depth + 1)
+                
+                extract_authors_from_messages(thread_elem)
+                logger.info(f"📄 XML READER: Found {len(author_list)} authors in threaded format")
+            else:
+                logger.warning("📄 XML READER: No authors found in either format")
+                author_list = []
 
         link = root.findall(".//atom:entry/atom:link", namespaces)[0].get('href')
         if "bitcoin-dev" in link:
@@ -139,6 +180,117 @@ class GenerateXML:
         with open(xml_file, 'wb') as f:
             f.write(feed_xml)
 
+    def generate_threaded_xml(self, feed_data, xml_file, thread_data=None):
+        """Generate XML with threading information preserved using nested structure"""
+        
+        logger.info(f"🧵 XML THREADING: Starting threaded XML generation for {xml_file}")
+        logger.info(f"📊 XML THREADING: Thread data provided: {'Yes' if thread_data else 'No'}")
+        
+        # Create the base XML structure manually for better control
+        from xml.dom import minidom
+        
+        # Create root feed element
+        feed = ET.Element('feed', xmlns='http://www.w3.org/2005/Atom')
+        
+        # Add basic feed metadata
+        ET.SubElement(feed, 'id').text = str(feed_data['id'])
+        ET.SubElement(feed, 'title').text = feed_data['title']
+        ET.SubElement(feed, 'updated').text = datetime.now(timezone.utc).isoformat()
+        
+        # Add generator info
+        generator = ET.SubElement(feed, 'generator', uri='https://lkiesow.github.io/python-feedgen', version='0.9.0')
+        generator.text = 'python-feedgen'
+        
+        if thread_data:
+            logger.info(f"📋 XML THREADING: Processing {len(thread_data)} threaded items")
+            
+            # Create thread structure
+            thread_element = ET.SubElement(feed, 'thread')
+            
+            # Build thread hierarchy
+            self._build_threaded_structure(thread_element, thread_data)
+            
+            logger.success(f"✅ XML THREADING: Built nested thread structure with {len(thread_data)} messages")
+        else:
+            logger.warning("⚠️ XML THREADING: No thread data, using flat author structure")
+            # Fallback to flat author list
+            for author in feed_data['authors']:
+                author_elem = ET.SubElement(feed, 'author')
+                ET.SubElement(author_elem, 'name').text = author
+        
+        # Add links
+        for link in feed_data['links']:
+            ET.SubElement(feed, 'link', href=link, rel='alternate')
+            
+        # Add main entry with summary
+        entry = ET.SubElement(feed, 'entry')
+        ET.SubElement(entry, 'id').text = str(feed_data['id'])
+        ET.SubElement(entry, 'title').text = feed_data['title']
+        ET.SubElement(entry, 'updated').text = datetime.now(timezone.utc).isoformat()
+        ET.SubElement(entry, 'link', href=feed_data['url'], rel='alternate')
+        ET.SubElement(entry, 'published').text = feed_data['created_at']
+        ET.SubElement(entry, 'summary').text = feed_data['summary']
+
+        # Pretty print and save XML
+        rough_string = ET.tostring(feed, 'unicode')
+        reparsed = minidom.parseString(rough_string)
+        pretty_xml = reparsed.toprettyxml(indent="  ")
+        
+        # Remove extra blank lines
+        pretty_xml = '\n'.join([line for line in pretty_xml.split('\n') if line.strip()])
+        
+        with open(xml_file, 'w', encoding='utf-8') as f:
+            f.write(pretty_xml)
+    
+    def _build_threaded_structure(self, parent_element, thread_data):
+        """
+        Build nested thread structure that exactly matches mailing list display order
+        
+        This creates a FLAT chronological list of messages with proper nesting attributes
+        for UI threading display, exactly like the mailing list shows.
+        """
+        
+        logger.info(f"🔍 XML THREADING: Building structure for {len(thread_data)} messages in mailing list order")
+        
+        # Sort by thread_position to get mailing list chronological order
+        sorted_data = sorted(thread_data, key=lambda x: x.get('thread_position', 0))
+        
+        logger.info("📋 Mailing list chronological order:")
+        for i, item in enumerate(sorted_data):
+            logger.info(f"  {i+1}: {item['author']} (pos={item.get('thread_position', 0)}, depth={item.get('thread_depth', 0)})")
+        
+        # Create message elements in exact mailing list order - NO DEEP NESTING
+        for i, thread_item in enumerate(sorted_data):
+            msg_id = f"msg_{i+1}"
+            author_name = thread_item['author']
+            timestamp = thread_item.get('created_at', '')
+            thread_depth = thread_item.get('thread_depth', 0)
+            reply_to = thread_item.get('reply_to_author', '')
+            parent_id = thread_item.get('parent_id', '')
+            anchor_id = thread_item.get('anchor_id', '')
+            
+            message = ET.Element('message')
+            message.set('id', msg_id)
+            message.set('depth', str(thread_depth))
+            message.set('position', str(i))
+            
+            if reply_to:
+                message.set('reply_to', reply_to)
+            if parent_id:
+                message.set('parent_id', str(parent_id))
+            if anchor_id:
+                message.set('anchor', str(anchor_id))
+            
+            ET.SubElement(message, 'author').text = author_name
+            ET.SubElement(message, 'timestamp').text = timestamp
+            
+            # Add directly to parent - FLAT structure in chronological order
+            parent_element.append(message)
+            
+            logger.info(f"    📧 {i+1}: '{author_name}' added (depth={thread_depth})")
+        
+        logger.success(f"✅ XML THREADING: Built flat structure with {len(sorted_data)} messages in perfect mailing list order")
+
     def append_columns(self, df_dict, file, title, namespace):
         """
         Extract specific information from the given XML file corresponding to
@@ -178,6 +330,18 @@ class GenerateXML:
         author_result = author_result.replace(":", "")
         author_result = author_result.replace("-", "")
         df_dict["authors"].append([author_result.strip()])
+        
+        # Extract the body/summary from the XML
+        summary = root.find('atom:entry/atom:summary', namespace).text
+        df_dict["body"].append(summary)
+        
+        # Add default values for threading fields (since XML files don't contain this data)
+        # These will be None/0 for existing XML files, as threading data only comes from ElasticSearch
+        df_dict["thread_depth"].append(0)  # Default to root level
+        df_dict["thread_position"].append(0)  # Default position
+        df_dict["parent_id"].append(None)  # No parent info in XML
+        df_dict["reply_to_author"].append(None)  # No reply info in XML
+        df_dict["anchor_id"].append(None)  # No anchor info in XML
 
     def file_not_present_df(self, columns, source_cols, df_dict, files_list, dict_data, data,
                             title, combined_filename, namespace):
@@ -195,7 +359,16 @@ class GenerateXML:
                 datetime_obj = add_utc_if_not_present(dict_data[data]['_source'][col], iso_format=False)
                 df_dict[col].append(datetime_obj)
             else:
-                df_dict[col].append(dict_data[data]['_source'][col])
+                # Handle threading fields that might not exist in older documents
+                if col in ['thread_depth', 'thread_position', 'parent_id', 'reply_to_author', 'anchor_id']:
+                    value = dict_data[data]['_source'].get(col, None)
+                    if col == 'thread_depth' and value is None:
+                        value = 0  # Default depth for root messages
+                    elif col == 'thread_position' and value is None:
+                        value = 0  # Default position
+                    df_dict[col].append(value)
+                else:
+                    df_dict[col].append(dict_data[data]['_source'][col])
 
         # For each individual summary (XML file) that exists for the
         # given thread, extract and append their content to the dictionary
@@ -213,18 +386,6 @@ class GenerateXML:
 
                 if title == file_title:
                     self.append_columns(df_dict, file, title, namespace)
-
-                    if combined_filename in file:
-                        # TODO: the code will never reach this point
-                        # as we are already filtering per thread title so no
-                        # "Combined summary - X" filename will pass though
-                        tree = ET.parse(file)
-                        root = tree.getroot()
-                        summary = root.find('atom:entry/atom:summary', namespace).text
-                        df_dict["body"].append(summary)
-                    else:
-                        summary = root.find('atom:entry/atom:summary', namespace).text
-                        df_dict["body"].append(summary)
             else:
                 logger.info(f"file not present: {file}")
 
@@ -271,14 +432,38 @@ class GenerateXML:
             logger.info("individual summaries are present but not combined ones ...")
             for file in individual_summaries_xmls_list:
                 self.append_columns(df_dict, file, title, namespace)
-                tree = ET.parse(file)
-                root = tree.getroot()
-                summary = root.find('atom:entry/atom:summary', namespace).text
-                df_dict["body"].append(summary)
 
     def preprocess_authors_name(self, author_tuple):
         author_tuple = tuple(s.replace('+', '').strip() for s in author_tuple)
         return author_tuple
+
+    def sort_by_thread_display_order(self, df):
+        """
+        Sort messages by proper mailing list display order (thread hierarchy)
+        to match the exact structure shown in mailing list archives.
+        
+        This uses chronological order as the primary sort within each thread level
+        to ensure the display matches the mailing list threading exactly.
+        """
+        if len(df) <= 1:
+            return df
+            
+        logger.info(f"🔄 THREADING SORT: Sorting {len(df)} messages by mailing list display order")
+        
+        # Sort by creation time first - this gives us the base chronological order
+        # that mailing lists use for their threading display
+        df_sorted = df.sort_values('created_at', ascending=True).reset_index(drop=True)
+        
+        logger.success(f"✅ THREADING SORT: Successfully sorted {len(df_sorted)} messages by chronological order")
+        
+        # Log the sorted order for debugging
+        for i, row in df_sorted.iterrows():
+            author_name = row['authors'][0] if row['authors'] else 'Unknown'
+            reply_to = row.get('reply_to_author', 'None')
+            created = str(row['created_at'])[:16] if 'created_at' in row else 'Unknown'
+            logger.info(f"    📧 {i}: {created} '{author_name}' -> '{reply_to}'")
+        
+        return df_sorted
 
     def get_local_xml_file_paths(self, dev_url):
         """
@@ -299,7 +484,7 @@ class GenerateXML:
         # Initialize a dictionary to store data for DataFrame construction, with predefined columns
         columns = ['_index', '_id', '_score']
         source_cols = ['body_type', 'created_at', 'id', 'title', 'body', 'type',
-                       'url', 'authors']
+                       'url', 'authors', 'thread_depth', 'thread_position', 'parent_id', 'reply_to_author', 'anchor_id']
         df_dict = {col: [] for col in (columns + source_cols)}
 
         seen_titles = set()
@@ -407,7 +592,8 @@ class GenerateXML:
                     title_df['authors'] = title_df['authors'].apply(convert_to_tuple)
                     title_df = title_df.drop_duplicates()
                     title_df['authors'] = title_df['authors'].apply(self.preprocess_authors_name)
-                    title_df = title_df.sort_values(by='created_at', ascending=False)
+                    # Sort by proper thread display order instead of chronological order
+                    title_df = self.sort_by_thread_display_order(title_df)
                     logger.info(f"Number of docs for title: {title}: {len(title_df)}")
 
                     # Handle threads with single and multiple documents differently
@@ -443,6 +629,46 @@ class GenerateXML:
                         # - the individual summaries of previous posts
                         # - the actual content of newer posts
                         combined_summary = create_summary(combined_body)
+                        
+                        # Prepare threading data if available
+                        thread_data = []
+                        logger.info(f"🧵 SUMMARIZER THREADING: Checking for threading data in {len(title_df)} documents")
+                        logger.info(f"📋 SUMMARIZER THREADING: Available columns: {list(title_df.columns)}")
+                        
+                        if 'thread_depth' in title_df.columns:
+                            logger.success("✅ SUMMARIZER THREADING: Threading columns found! Processing...")
+                            # Process rows in the order they appear in the sorted DataFrame
+                            # This preserves the proper thread display order from sort_by_thread_display_order
+                            for display_position, (idx, row) in enumerate(title_df.iterrows()):
+                                # Extract anchor ID from the document ID (Elasticsearch format)
+                                anchor_id = ''
+                                if row.get('id'):
+                                    # ES document ID format: mailing-list-2025-07-m376871ab5341f27343e4e85b66d86ca373a5b857
+                                    doc_id = str(row['id'])
+                                    if 'm' in doc_id and len(doc_id) > 20:
+                                        # Extract the hash part after the last 'm'
+                                        parts = doc_id.split('-m')
+                                        if len(parts) > 1:
+                                            anchor_id = 'm' + parts[-1]
+                                    logger.info(f"    🔗 ANCHOR EXTRACTION: doc_id='{doc_id}' -> anchor_id='{anchor_id}'")
+                                
+                                thread_item = {
+                                    'author': row['authors'][0] if row['authors'] else 'Unknown',
+                                    'created_at': str(row['created_at']),
+                                    'thread_depth': row.get('thread_depth', 0),
+                                    'thread_position': display_position,  # Use display position, not original position
+                                    'original_position': row.get('thread_position', 0),  # Keep original for reference
+                                    'reply_to_author': row.get('reply_to_author', ''),
+                                    'parent_id': row.get('parent_id', ''),
+                                    'anchor_id': anchor_id
+                                }
+                                thread_data.append(thread_item)
+                                logger.info(f"    📧 SUMMARIZER THREADING: #{display_position}: '{thread_item['author']}' depth={thread_item['thread_depth']} -> '{thread_item['reply_to_author']}' anchor='{anchor_id}' (orig_pos: {thread_item['original_position']})")
+                            
+                            logger.success(f"✅ SUMMARIZER THREADING: Collected {len(thread_data)} items with threading data in proper display order")
+                        else:
+                            logger.warning("⚠️ SUMMARIZER THREADING: No 'thread_depth' column found - documents may not have threading data")
+                        
                         feed_data = {
                             'id': "2",
                             'title': 'Combined summary - ' + title,
@@ -455,10 +681,17 @@ class GenerateXML:
                         # We use a flag to check if the XML file for the
                         # combined summary is generated for the first time
                         if not flag:
-                            # Generate XML only once for the first month-year and keep its path
-                            self.generate_xml(feed_data, file_path)
+                            # Generate XML with threading information if available
+                            if thread_data:
+                                logger.success(f"🎯 SUMMARIZER THREADING: Using THREADED XML generation for {file_path}")
+                                logger.info(f"📊 SUMMARIZER THREADING: Will process {len(thread_data)} threaded items")
+                                self.generate_threaded_xml(feed_data, file_path, thread_data)
+                            else:
+                                logger.warning(f"⚠️ SUMMARIZER THREADING: Using FLAT XML generation (no threading data) for {file_path}")
+                                self.generate_xml(feed_data, file_path)
                             std_file_path = file_path
                             flag = True
+                            logger.success(f"✅ SUMMARIZER THREADING: XML file generated successfully: {file_path}")
                         else:
                             # For subsequent month-year groups, copy the initially
                             # created XML file instead of creating a new one

--- a/xml_threading_updater.py
+++ b/xml_threading_updater.py
@@ -1,0 +1,294 @@
+import os
+import time
+from datetime import datetime
+import sys
+import xml.etree.ElementTree as ET
+from xml.dom import minidom
+from loguru import logger
+import warnings
+
+from src.config import ES_INDEX
+from src.elasticsearch_utils import ElasticSearchClient
+from src.xml_utils import GenerateXML
+
+warnings.filterwarnings("ignore")
+
+
+class XMLThreadingUpdater:
+    def __init__(self):
+        self.elastic_search = ElasticSearchClient()
+        self.gen = GenerateXML()
+
+    def has_threading_structure(self, xml_file_path):
+        """Check if XML file already has threading structure"""
+        try:
+            tree = ET.parse(xml_file_path)
+            root = tree.getroot()
+            return root.find('.//{http://www.w3.org/2005/Atom}thread') is not None
+        except Exception as e:
+            logger.error(f"Error checking threading structure in {xml_file_path}: {e}")
+            return False
+
+    def extract_existing_summary_and_metadata(self, xml_file_path):
+        """Extract existing summary and metadata from XML file"""
+        try:
+            namespaces = {'atom': 'http://www.w3.org/2005/Atom'}
+            tree = ET.parse(xml_file_path)
+            root = tree.getroot()
+            
+            # Extract existing data
+            title_elem = root.find('.//atom:entry/atom:title', namespaces)
+            title = title_elem.text if title_elem is not None else None
+            
+            summary_elem = root.find('.//atom:entry/atom:summary', namespaces)
+            summary = summary_elem.text if summary_elem is not None else None
+            
+            url_elem = root.find('.//atom:entry/atom:link', namespaces)
+            url = url_elem.get('href') if url_elem is not None else None
+            
+            published_elem = root.find('.//atom:entry/atom:published', namespaces)
+            published = published_elem.text if published_elem is not None else None
+            
+            # Extract links to individual XML files
+            links = []
+            link_elements = root.findall('.//atom:link[@rel="alternate"]', namespaces)
+            for link_elem in link_elements:
+                href = link_elem.get('href')
+                if href:
+                    links.append(href)
+            
+            return {
+                'title': title,
+                'summary': summary,
+                'url': url,
+                'published': published,
+                'links': links
+            }
+        except Exception as e:
+            logger.error(f"Error extracting data from {xml_file_path}: {e}")
+            return None
+
+    def get_threading_data_for_title(self, title, dev_url):
+        """Fetch threading data from Elasticsearch for a specific title"""
+        try:
+            title_dict_data = self.elastic_search.fetch_data_based_on_title(
+                es_index=ES_INDEX, title=title, url=dev_url
+            )
+            
+            if not title_dict_data:
+                logger.warning(f"No data found in ES for title: {title}")
+                return []
+            
+            thread_data = []
+            logger.info(f"🔍 THREADING UPDATER: Found {len(title_dict_data)} documents for title: {title}")
+            
+            # Sort by creation time to get proper chronological order
+            title_dict_data.sort(key=lambda x: x['_source']['created_at'])
+            
+            for display_position, doc in enumerate(title_dict_data):
+                source = doc['_source']
+                
+                # Extract anchor ID from document ID
+                anchor_id = ''
+                if source.get('id'):
+                    doc_id = str(source['id'])
+                    if 'm' in doc_id and len(doc_id) > 20:
+                        parts = doc_id.split('-m')
+                        if len(parts) > 1:
+                            anchor_id = 'm' + parts[-1]
+                
+                thread_item = {
+                    'author': source.get('authors', ['Unknown'])[0] if source.get('authors') else 'Unknown',
+                    'created_at': source.get('created_at', ''),
+                    'thread_depth': source.get('thread_depth', 0),
+                    'thread_position': display_position,
+                    'reply_to_author': source.get('reply_to_author', ''),
+                    'parent_id': source.get('parent_id', ''),
+                    'anchor_id': anchor_id
+                }
+                thread_data.append(thread_item)
+                
+                logger.info(f"    📧 THREADING UPDATER: #{display_position}: '{thread_item['author']}' depth={thread_item['thread_depth']} -> '{thread_item['reply_to_author']}' anchor='{anchor_id}'")
+            
+            return thread_data
+            
+        except Exception as e:
+            logger.error(f"Error fetching threading data for title '{title}': {e}")
+            return []
+
+    def update_xml_with_threading(self, xml_file_path, thread_data, existing_data):
+        """Update XML file with threading structure while preserving existing summary"""
+        try:
+            logger.info(f"🔄 THREADING UPDATER: Updating {xml_file_path} with threading structure")
+            
+            # Create new XML structure with threading
+            feed = ET.Element('feed', xmlns='http://www.w3.org/2005/Atom')
+            
+            # Add basic feed metadata
+            ET.SubElement(feed, 'id').text = "2"
+            ET.SubElement(feed, 'title').text = existing_data['title']
+            ET.SubElement(feed, 'updated').text = datetime.now().isoformat() + '+00:00'
+            
+            # Add generator info
+            generator = ET.SubElement(feed, 'generator', uri='https://lkiesow.github.io/python-feedgen', version='0.9.0')
+            generator.text = 'python-feedgen'
+            
+            # Add threading structure if we have thread data
+            if thread_data:
+                logger.info(f"📋 THREADING UPDATER: Adding threading structure with {len(thread_data)} messages")
+                thread_element = ET.SubElement(feed, 'thread')
+                self.gen._build_threaded_structure(thread_element, thread_data)
+            else:
+                logger.warning("⚠️ THREADING UPDATER: No thread data available, keeping flat structure")
+            
+            # Add links to individual XML files
+            for link in existing_data['links']:
+                ET.SubElement(feed, 'link', href=link, rel='alternate')
+            
+            # Add main entry with existing summary (PRESERVE EXISTING SUMMARY)
+            entry = ET.SubElement(feed, 'entry')
+            ET.SubElement(entry, 'id').text = "2"
+            ET.SubElement(entry, 'title').text = existing_data['title']
+            ET.SubElement(entry, 'updated').text = datetime.now().isoformat() + '+00:00'
+            ET.SubElement(entry, 'link', href=existing_data['url'], rel='alternate')
+            ET.SubElement(entry, 'published').text = existing_data['published']
+            ET.SubElement(entry, 'summary').text = existing_data['summary']  # KEEP EXISTING SUMMARY
+            
+            # Pretty print and save XML
+            rough_string = ET.tostring(feed, 'unicode')
+            reparsed = minidom.parseString(rough_string)
+            pretty_xml = reparsed.toprettyxml(indent="  ")
+            
+            # Remove extra blank lines
+            pretty_xml = '\n'.join([line for line in pretty_xml.split('\n') if line.strip()])
+            
+            # Write updated XML file
+            with open(xml_file_path, 'w', encoding='utf-8') as f:
+                f.write(pretty_xml)
+            
+            logger.success(f"✅ THREADING UPDATER: Successfully updated {xml_file_path} with threading structure")
+            return True
+            
+        except Exception as e:
+            logger.error(f"❌ THREADING UPDATER: Error updating {xml_file_path}: {e}")
+            return False
+
+    def find_combined_xml_files(self, base_directory="static/bitcoin-dev"):
+        """Find all combined XML files that need threading updates"""
+        combined_files = []
+        
+        for root, _, files in os.walk(base_directory):
+            for file in files:
+                if file.startswith('combined_') and file.endswith('.xml'):
+                    file_path = os.path.join(root, file)
+                    combined_files.append(file_path)
+        
+        logger.info(f"📁 THREADING UPDATER: Found {len(combined_files)} combined XML files")
+        return combined_files
+
+    def extract_title_from_filename(self, xml_file_path):
+        """Extract the original title from combined XML filename"""
+        try:
+            # Get filename without path and extension
+            filename = os.path.basename(xml_file_path)
+            
+            # Try to extract title from existing XML first
+            existing_data = self.extract_existing_summary_and_metadata(xml_file_path)
+            if existing_data and existing_data['title']:
+                # Remove "Combined summary - " prefix to get original title
+                original_title = existing_data['title'].replace('Combined summary - ', '')
+                return original_title
+            
+            logger.warning(f"Could not extract title from {xml_file_path}")
+            return None
+            
+        except Exception as e:
+            logger.error(f"Error extracting title from {xml_file_path}: {e}")
+            return None
+
+    def update_all_threading(self, start_year=None):
+        """Update all combined XML files with threading structure"""
+        dev_url = "https://gnusha.org/pi/bitcoindev/"  # Only bitcoin-dev
+        
+        logger.info("🚀 THREADING UPDATER: Starting threading update for bitcoin-dev")
+        if start_year:
+            logger.info(f"📅 THREADING UPDATER: Processing from year {start_year}")
+        
+        # Find all combined XML files
+        combined_files = self.find_combined_xml_files()
+        
+        updated_count = 0
+        skipped_count = 0
+        error_count = 0
+        
+        for xml_file_path in combined_files:
+            try:
+                # Skip if filtering by year
+                if start_year:
+                    # Extract year from path (e.g., "March_2022")
+                    path_parts = xml_file_path.split('/')
+                    for part in path_parts:
+                        if '_' in part and part.split('_')[-1].isdigit():
+                            file_year = int(part.split('_')[-1])
+                            if file_year < int(start_year):
+                                logger.info(f"⏭️ THREADING UPDATER: Skipping {xml_file_path} (year {file_year} < {start_year})")
+                                skipped_count += 1
+                                continue
+                            break
+                
+                # Check if already has threading
+                if self.has_threading_structure(xml_file_path):
+                    logger.info(f"✅ THREADING UPDATER: {xml_file_path} already has threading structure")
+                    skipped_count += 1
+                    continue
+                
+                logger.info(f"🔄 THREADING UPDATER: Processing {xml_file_path}")
+                
+                # Extract existing data
+                existing_data = self.extract_existing_summary_and_metadata(xml_file_path)
+                if not existing_data:
+                    logger.error(f"❌ THREADING UPDATER: Could not extract data from {xml_file_path}")
+                    error_count += 1
+                    continue
+                
+                # Extract title
+                title = self.extract_title_from_filename(xml_file_path)
+                if not title:
+                    logger.error(f"❌ THREADING UPDATER: Could not extract title from {xml_file_path}")
+                    error_count += 1
+                    continue
+                
+                # Get threading data from Elasticsearch
+                thread_data = self.get_threading_data_for_title(title, dev_url)
+                
+                # Update XML with threading
+                if self.update_xml_with_threading(xml_file_path, thread_data, existing_data):
+                    updated_count += 1
+                else:
+                    error_count += 1
+                
+                # Small delay to avoid overwhelming the system
+                time.sleep(0.1)
+                
+            except Exception as e:
+                logger.error(f"❌ THREADING UPDATER: Error processing {xml_file_path}: {e}")
+                error_count += 1
+        
+        logger.success(f"🎉 THREADING UPDATER: Completed! Updated: {updated_count}, Skipped: {skipped_count}, Errors: {error_count}")
+
+
+if __name__ == "__main__":
+    # Get parameters from environment or command line
+    start_year = os.environ.get('START_YEAR')
+    update_threading_only = os.environ.get('UPDATE_THREADING_ONLY', 'false').lower() == 'true'
+    
+    if len(sys.argv) > 1:
+        start_year = sys.argv[1] if sys.argv[1] else None
+    
+    updater = XMLThreadingUpdater()
+    
+    if update_threading_only or start_year:
+        logger.info("🧵 THREADING UPDATER: Running in threading update mode")
+        updater.update_all_threading(start_year=start_year)
+    else:
+        logger.info("ℹ️ THREADING UPDATER: No threading update requested")

--- a/xmls_generator_production.py
+++ b/xmls_generator_production.py
@@ -1,4 +1,5 @@
 import time
+import os
 from datetime import datetime, timedelta
 import sys
 from loguru import logger
@@ -7,6 +8,7 @@ from openai.error import APIError, PermissionError, AuthenticationError, Invalid
 from src.config import ES_INDEX
 from src.elasticsearch_utils import ElasticSearchClient
 from src.xml_utils import GenerateXML
+from xml_threading_updater import XMLThreadingUpdater
 
 warnings.filterwarnings("ignore")
 
@@ -18,14 +20,18 @@ if __name__ == "__main__":
         "https://gnusha.org/pi/bitcoindev/",
         "https://mailing-list.bitcoindevs.xyz/bitcoindev/"
     ]
+    
+    logger.info("📋 XML GENERATOR: Processing bitcoin-dev and delvingbitcoin domains")
 
+    # Calculate date range - 30 days as per original main branch
     end_date = datetime.now()
     start_date = end_date - timedelta(days=30)
+    logger.info("📅 XML GENERATOR: Using default 30 days range")
 
     # yyyy-mm-dd
     end_date_str = end_date.strftime("%Y-%m-%d")
     start_date_str = start_date.strftime("%Y-%m-%d")
-    logger.info(f"start_data: {start_date_str}")
+    logger.info(f"start_date: {start_date_str}")
     logger.info(f"end_date_str: {end_date_str}")
 
     for dev_url in dev_urls:
@@ -50,4 +56,13 @@ if __name__ == "__main__":
                 if count_main > 5:
                     sys.exit(ex)
 
-    logger.info("Process Complete.")
+    # After processing, update threading for all XMLs (including newly created ones)
+    logger.info("🧵 XML GENERATOR: Starting threading update for all XMLs...")
+    try:
+        updater = XMLThreadingUpdater()
+        updater.update_all_threading()
+        logger.success("✅ XML GENERATOR: Threading update completed successfully")
+    except Exception as e:
+        logger.error(f"❌ XML GENERATOR: Error during threading update: {e}")
+
+    logger.info("🎉 Process Complete.")


### PR DESCRIPTION
This PR implements threaded XML generation that preserves reply relationships (parent-child) in generated XML files

- Supports both flat and threaded author formats  
- Support new threading fields from ElasticSearch: `thread_depth`, `thread_position`, `reply_to_author`, `parent_id`
- This is still backward compatible with existing XML files (old strcuture)

PS: There are many debug logs in the code to help trace job actions in CI. These will be removed once all XML files are updated