### PR TITLE
Change Open AI model to gpt4-turbo

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -23,7 +23,7 @@ CHATGPT = True
 COMPLETION_MODEL = "text-davinci-003"  # "text-ada-001"
 
 # used in generation of xmls production, homepage, newsletter etc.
-CHAT_COMPLETION_MODEL = "gpt-4-turbo-preview"  # "gpt-3.5-turbo", "gpt-4"
+CHAT_COMPLETION_MODEL = "gpt-4-turbo"  # "gpt-3.5-turbo", "gpt-4"
 
 ES_CLOUD_ID = os.getenv("ES_CLOUD_ID")
 ES_USERNAME = os.getenv("ES_USERNAME")


### PR DESCRIPTION
The previous mode gpt-4-turbo-preview has been deprecaited by openai turbo  now gpt-4-turbo is stable so we can use that